### PR TITLE
オリジンが404を返した場合はクライアントにも404を返すようにする

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,13 +132,24 @@ func proxy(w http.ResponseWriter, r *http.Request) {
 	}
 	var buf *bytes.Buffer
 	if pathExt == ".webp" {
-		buf, err = convWebp(orgRes.Body, []string{})
-		defer buf.Reset()
+		resBytes, err := io.ReadAll(orgRes.Body)
+		if err != nil {
+			http.Error(w, "Read origin body failed", http.StatusInternalServerError)
+			log.Printf("Read origin body failed. %v\n", err)
+			return
+		}
+
+		body := io.NopCloser(bytes.NewBuffer(resBytes))
+		defer body.Close()
+		buf, err = convWebp(body, []string{})
 		if err == nil {
+			defer buf.Reset()
 			w.Header().Set("Content-Type", "image/webp")
 		} else {
 			// if err, normally convertion will be proceeded
-			buf, err = convert(orgRes.Body, quality)
+			body = io.NopCloser(bytes.NewBuffer(resBytes))
+			defer body.Close()
+			buf, err = convert(body, quality)
 			if err != nil {
 				http.Error(w, "Image convert failed", http.StatusInternalServerError)
 				log.Printf("Image convert failed. %v\n", err)

--- a/main_test.go
+++ b/main_test.go
@@ -161,6 +161,27 @@ func TestOriginNotExist(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if res.StatusCode != http.StatusNotFound {
+		t.Errorf("HTTP status is %d, want %d", res.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestOriginBadGateWay(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(proxy))
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "502 Bad Gateway", http.StatusBadGateway)
+	}))
+
+	orgSrvURL = origin.URL
+
+	url := ts.URL + "/bad.jpg"
+
+	res, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if res.StatusCode != http.StatusBadGateway {
 		t.Errorf("HTTP status is %d, want %d", res.StatusCode, http.StatusBadGateway)
 	}


### PR DESCRIPTION
現状はオリジンにファイルが存在しない場合も500系のエラーを返すようになっています。
500系のエラーでアラートを設定する際に不便なので404の場合はクライアントに404を返すようにします。