### PR TITLE
cwebpではなくbimgを使ってwebp変換する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt update
-        sudo apt install -y webp
+        sudo apt install -y webp libvips-dev
     - name: Setup Go
       uses: actions/setup-go@v3
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,18 @@ ARG OYAKI_VERSION
 WORKDIR /go/src/oyaki
 COPY . /go/src/oyaki
 
-RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=${OYAKI_VERSION}" -o /go/bin/oyaki
-RUN apt update && apt install -y curl \
+RUN apt update && apt install -y curl libvips-dev \
  && curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.3.1-linux-x86-64.tar.gz --output libwebp.tar.gz \
  && tar vzxf libwebp.tar.gz \
  && mv libwebp-1.3.1-linux-x86-64/bin/cwebp /go/bin/
+RUN go build -ldflags "-s -w -X main.version=${OYAKI_VERSION}" -o /go/bin/oyaki
 
-FROM gcr.io/distroless/static-debian11
+FROM debian:bookworm
 
 COPY --from=build /go/bin/oyaki /
 COPY --from=build /go/bin/cwebp /bin/
+
+RUN apt update && apt install -y libvips-dev
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,18 +5,14 @@ ARG OYAKI_VERSION
 WORKDIR /go/src/oyaki
 COPY . /go/src/oyaki
 
-RUN apt update && apt install -y curl libvips-dev \
- && curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.3.1-linux-x86-64.tar.gz --output libwebp.tar.gz \
- && tar vzxf libwebp.tar.gz \
- && mv libwebp-1.3.1-linux-x86-64/bin/cwebp /go/bin/
+RUN apt update && apt install -y libvips-dev
 RUN go build -ldflags "-s -w -X main.version=${OYAKI_VERSION}" -o /go/bin/oyaki
 
 FROM debian:bookworm
 
-COPY --from=build /go/bin/oyaki /
-COPY --from=build /go/bin/cwebp /bin/
-
 RUN apt update && apt install -y libvips-dev
+
+COPY --from=build /go/bin/oyaki /
 
 EXPOSE 8080
 

--- a/convert.go
+++ b/convert.go
@@ -12,16 +12,13 @@ func convert(src io.Reader, q int) (*bytes.Buffer, error) {
 	if err != nil {
 		return nil, err
 	}
-	img, err := bimg.NewImage(out).AutoRotate()
-	if err != nil {
-		return nil, err
-	}
 
-	processed, err := bimg.NewImage(img).Process(bimg.Options{Quality: quality})
-	if err != nil {
-		return nil, err
+	opts := bimg.Options{
+		Type:    bimg.JPEG,
+		Quality: quality,
+		// NoAutoRotateはデフォルトでfalseで、勝手にrotateしてくれる
 	}
-	jpegImg, err := bimg.NewImage(processed).Convert(bimg.JPEG)
+	jpegImg, err := bimg.NewImage(out).Process(opts)
 	if err != nil {
 		return nil, err
 	}

--- a/convert.go
+++ b/convert.go
@@ -2,23 +2,29 @@ package main
 
 import (
 	"bytes"
-	"image/jpeg"
 	"io"
 
-	"github.com/disintegration/imaging"
+	"github.com/h2non/bimg"
 )
 
 func convert(src io.Reader, q int) (*bytes.Buffer, error) {
-	img, err := imaging.Decode(src, imaging.AutoOrientation(true))
+	out, err := io.ReadAll(src)
+	if err != nil {
+		return nil, err
+	}
+	img, err := bimg.NewImage(out).AutoRotate()
 	if err != nil {
 		return nil, err
 	}
 
-	buf := new(bytes.Buffer)
-
-	if err := jpeg.Encode(buf, img, &jpeg.Options{Quality: quality}); err != nil {
+	processed, err := bimg.NewImage(img).Process(bimg.Options{Quality: quality})
+	if err != nil {
+		return nil, err
+	}
+	jpegImg, err := bimg.NewImage(processed).Convert(bimg.JPEG)
+	if err != nil {
 		return nil, err
 	}
 
-	return buf, nil
+	return bytes.NewBuffer(jpegImg), nil
 }

--- a/convert.go
+++ b/convert.go
@@ -13,12 +13,17 @@ func convert(src io.Reader, q int) (*bytes.Buffer, error) {
 		return nil, err
 	}
 
+	// 動作検証の結果こちらは明示的にAutoRotateしないと動かなかった
+	img, err := bimg.NewImage(out).AutoRotate()
+	if err != nil {
+		return nil, err
+	}
+
 	opts := bimg.Options{
 		Type:    bimg.JPEG,
 		Quality: quality,
-		// NoAutoRotateはデフォルトでfalseで、勝手にrotateしてくれる
 	}
-	jpegImg, err := bimg.NewImage(out).Process(opts)
+	jpegImg, err := bimg.NewImage(img).Process(opts)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/pepabo/oyaki
 
 go 1.19
 
-require github.com/disintegration/imaging v1.6.2
+require (
+	github.com/disintegration/imaging v1.6.2
+	github.com/h2non/bimg v1.1.9
+)
 
 require golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,4 @@ module github.com/pepabo/oyaki
 
 go 1.19
 
-require (
-	github.com/disintegration/imaging v1.6.2
-	github.com/h2non/bimg v1.1.9
-)
-
-require golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 // indirect
+require github.com/h2non/bimg v1.1.9

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,2 @@
-github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
-github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
 github.com/h2non/bimg v1.1.9 h1:WH20Nxko9l/HFm4kZCA3Phbgu2cbHvYzxwxn9YROEGg=
 github.com/h2non/bimg v1.1.9/go.mod h1:R3+UiYwkK4rQl6KVFTOFJHitgLbZXBZNFh2cv3AEbp8=
-golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 h1:hVwzHzIUGRjiF7EcUjqNxk3NCfkPxbDKRdnNE1Rpg0U=
-golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
+github.com/h2non/bimg v1.1.9 h1:WH20Nxko9l/HFm4kZCA3Phbgu2cbHvYzxwxn9YROEGg=
+github.com/h2non/bimg v1.1.9/go.mod h1:R3+UiYwkK4rQl6KVFTOFJHitgLbZXBZNFh2cv3AEbp8=
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 h1:hVwzHzIUGRjiF7EcUjqNxk3NCfkPxbDKRdnNE1Rpg0U=
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/main.go
+++ b/main.go
@@ -147,7 +147,7 @@ func proxy(w http.ResponseWriter, r *http.Request) {
 
 		body := io.NopCloser(bytes.NewBuffer(resBytes))
 		defer body.Close()
-		buf, err = convWebp(body)
+		buf, err = convWebp(body, quality)
 		if err == nil {
 			defer buf.Reset()
 			w.Header().Set("Content-Type", "image/webp")

--- a/main.go
+++ b/main.go
@@ -147,7 +147,7 @@ func proxy(w http.ResponseWriter, r *http.Request) {
 
 		body := io.NopCloser(bytes.NewBuffer(resBytes))
 		defer body.Close()
-		buf, err = convWebp(body, []string{})
+		buf, err = convWebp(body)
 		if err == nil {
 			defer buf.Reset()
 			w.Header().Set("Content-Type", "image/webp")

--- a/webp.go
+++ b/webp.go
@@ -41,7 +41,7 @@ func doWebp(req *http.Request) (*http.Response, error) {
 	return orgRes, nil
 }
 
-func convWebp(src io.Reader, params []string) (*bytes.Buffer, error) {
+func convWebp(src io.Reader) (*bytes.Buffer, error) {
 	out, err := io.ReadAll(src)
 	if err != nil {
 		return nil, err

--- a/webp.go
+++ b/webp.go
@@ -41,17 +41,17 @@ func doWebp(req *http.Request) (*http.Response, error) {
 	return orgRes, nil
 }
 
-func convWebp(src io.Reader) (*bytes.Buffer, error) {
+func convWebp(src io.Reader, quality int) (*bytes.Buffer, error) {
 	out, err := io.ReadAll(src)
 	if err != nil {
 		return nil, err
 	}
-	img, err := bimg.NewImage(out).AutoRotate()
-	if err != nil {
-		return nil, err
+	opts := bimg.Options{
+		Type:    bimg.WEBP,
+		Quality: quality,
+		// NoAutoRotateはデフォルトでfalseで、勝手にrotateしてくれる
 	}
-
-	webpImg, err := bimg.NewImage(img).Convert(bimg.WEBP)
+	webpImg, err := bimg.NewImage(out).Process(opts)
 	if err != nil {
 		return nil, err
 	}

--- a/webp.go
+++ b/webp.go
@@ -51,7 +51,12 @@ func convWebp(src io.Reader) (*bytes.Buffer, error) {
 		return nil, err
 	}
 
-	webpImg, err := bimg.NewImage(img).Convert(bimg.WEBP)
+	processed, err := bimg.NewImage(img).Process(bimg.Options{Quality: 75})
+	if err != nil {
+		return nil, err
+	}
+
+	webpImg, err := bimg.NewImage(processed).Convert(bimg.WEBP)
 	if err != nil {
 		return nil, err
 	}

--- a/webp.go
+++ b/webp.go
@@ -51,12 +51,7 @@ func convWebp(src io.Reader) (*bytes.Buffer, error) {
 		return nil, err
 	}
 
-	processed, err := bimg.NewImage(img).Process(bimg.Options{Quality: 75})
-	if err != nil {
-		return nil, err
-	}
-
-	webpImg, err := bimg.NewImage(processed).Convert(bimg.WEBP)
+	webpImg, err := bimg.NewImage(img).Convert(bimg.WEBP)
 	if err != nil {
 		return nil, err
 	}

--- a/webp.go
+++ b/webp.go
@@ -47,8 +47,9 @@ func convWebp(src io.Reader, quality int) (*bytes.Buffer, error) {
 		return nil, err
 	}
 	opts := bimg.Options{
-		Type:    bimg.WEBP,
-		Quality: quality,
+		Type:         bimg.WEBP,
+		Quality:      quality,
+		NoAutoRotate: false,
 		// NoAutoRotateはデフォルトでfalseで、勝手にrotateしてくれる
 	}
 	webpImg, err := bimg.NewImage(out).Process(opts)

--- a/webp_test.go
+++ b/webp_test.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"bytes"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
 	"testing"
+
+	"github.com/disintegration/imaging"
 )
 
 func TestProxyWebP(t *testing.T) {
@@ -48,9 +53,74 @@ func TestConvJPG2WebP(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
-	_, err = convWebp(resp.Body, []string{})
+	_, err = convWebp(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
 
+}
+
+func BenchmarkConvJPG2WebP_OldCwebpMethod(b *testing.B) {
+	tmpF, err := os.CreateTemp("/tmp", "")
+	if err != nil {
+		b.Fatal("failed to create tmp file")
+	}
+	defer tmpF.Close()
+	defer os.Remove(tmpF.Name())
+
+	f, err := os.Open("./testdata/oyaki.jpg")
+	if err != nil {
+		b.Fatal("failed to open testdata")
+	}
+	defer f.Close()
+
+	// to re-use src bytes
+	src, err := io.ReadAll(f)
+	if err != nil {
+		b.Fatal("failed to open testdata")
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		srcBuf := bytes.NewBuffer(src)
+		b.StartTimer()
+		img, err := imaging.Decode(srcBuf, imaging.AutoOrientation(true))
+		if err != nil {
+			b.Fail()
+		}
+
+		if err := imaging.Encode(tmpF, img, imaging.JPEG); err != nil {
+			b.Fail()
+		}
+
+		params := []string{"-quiet", "-mt", "-jpeg_like", f.Name(), "-o", "-"}
+		if _, err = exec.Command("cwebp", params...).Output(); err != nil {
+			b.Fail()
+		}
+	}
+}
+
+func BenchmarkConvJPG2WebP_bimg(b *testing.B) {
+	f, err := os.Open("./testdata/oyaki.jpg")
+	if err != nil {
+		b.Fatal("failed to open testdata")
+	}
+	defer f.Close()
+
+	// to re-use src bytes
+	src, err := io.ReadAll(f)
+	if err != nil {
+		b.Fatal("failed to open testdata")
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		srcBuf := bytes.NewBuffer(src)
+		b.StartTimer()
+		if _, err = convWebp(srcBuf); err != nil {
+			b.Fail()
+		}
+	}
 }

--- a/webp_test.go
+++ b/webp_test.go
@@ -6,10 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"os/exec"
 	"testing"
-
-	"github.com/disintegration/imaging"
 )
 
 func TestProxyWebP(t *testing.T) {
@@ -58,47 +55,6 @@ func TestConvJPG2WebP(t *testing.T) {
 		t.Fatal(err)
 	}
 
-}
-
-func BenchmarkConvJPG2WebP_OldCwebpMethod(b *testing.B) {
-	tmpF, err := os.CreateTemp("/tmp", "")
-	if err != nil {
-		b.Fatal("failed to create tmp file")
-	}
-	defer tmpF.Close()
-	defer os.Remove(tmpF.Name())
-
-	f, err := os.Open("./testdata/oyaki.jpg")
-	if err != nil {
-		b.Fatal("failed to open testdata")
-	}
-	defer f.Close()
-
-	// to re-use src bytes
-	src, err := io.ReadAll(f)
-	if err != nil {
-		b.Fatal("failed to open testdata")
-	}
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		b.StopTimer()
-		srcBuf := bytes.NewBuffer(src)
-		b.StartTimer()
-		img, err := imaging.Decode(srcBuf, imaging.AutoOrientation(true))
-		if err != nil {
-			b.Fail()
-		}
-
-		if err := imaging.Encode(tmpF, img, imaging.JPEG); err != nil {
-			b.Fail()
-		}
-
-		params := []string{"-quiet", "-mt", "-jpeg_like", f.Name(), "-o", "-"}
-		if _, err = exec.Command("cwebp", params...).Output(); err != nil {
-			b.Fail()
-		}
-	}
 }
 
 func BenchmarkConvJPG2WebP_bimg(b *testing.B) {

--- a/webp_test.go
+++ b/webp_test.go
@@ -50,7 +50,7 @@ func TestConvJPG2WebP(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
-	_, err = convWebp(resp.Body)
+	_, err = convWebp(resp.Body, 90)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +75,7 @@ func BenchmarkConvJPG2WebP_bimg(b *testing.B) {
 		b.StopTimer()
 		srcBuf := bytes.NewBuffer(src)
 		b.StartTimer()
-		if _, err = convWebp(srcBuf); err != nil {
+		if _, err = convWebp(srcBuf, 90); err != nil {
 			b.Fail()
 		}
 	}


### PR DESCRIPTION
外部コマンドでcwebpを使って変換するのではなく、bimg(libvips)で変換するように書き換えました。
Cライブラリを使うためにDockerfileのベースイメージをdistrolessからdebianに変え、 `CGO_ENABLED=0` を削除しました。

また、imagingを使って変換していた(webpではない)プロキシも置き換えました

## ベンチマーク

従来の方法

```
BenchmarkProxyJpeg-12                      	      36	  32134368 ns/op	 2732786 B/op	     305 allocs/op
BenchmarkProxyPNG-12                       	     741	   1539859 ns/op	 5365531 B/op	     226 allocs/op
BenchmarkConvJPG2WebP_OldCwebpMethod-12    	      13	  85976654 ns/op	 1777722 B/op	     186 allocs/op
```

置き換え後
quality指定なし
```
BenchmarkProxyJpeg-12            	      67	  17042145 ns/op	 3866607 B/op	     249 allocs/op
BenchmarkProxyPNG-12             	     762	   1599133 ns/op	 5365836 B/op	     226 allocs/op
BenchmarkConvJPG2WebP_bimg-12    	      26	  44308845 ns/op	 3308000 B/op	      31 allocs/op
```

quality指定あり
```
BenchmarkProxyJpeg-12            	      81	  13760491 ns/op	 4392313 B/op	     247 allocs/op
BenchmarkProxyPNG-12             	     758	   1431104 ns/op	 5362828 B/op	     227 allocs/op
BenchmarkConvJPG2WebP_bimg-12    	      21	  58375780 ns/op	 3381610 B/op	      31 allocs/op
```