### PR TITLE
webp変換時にEXIFを残しておくと一部のブラウザで重複して回転してしまうのを修正

### DIFF
--- a/webp.go
+++ b/webp.go
@@ -51,6 +51,10 @@ func convWebp(src io.Reader, quality int) (*bytes.Buffer, error) {
 		Quality:      quality,
 		NoAutoRotate: false,
 		// NoAutoRotateはデフォルトでfalseで、勝手にrotateしてくれる
+
+		// Safariなどでは、bimgによってEXIFの回転処理を実施したあとにブラウザ側でEXIFを読んで再度回転してしまうことがあるので、
+		// EXIFは削除する
+		StripMetadata: true,
 	}
 	webpImg, err := bimg.NewImage(out).Process(opts)
 	if err != nil {


### PR DESCRIPTION
表題のとおりです。

WebP変換前のオリジン画像のEXIF Orientationで回転が設定されていたとき、
`bimg.Process()` を実行したタイミングで回転処理が適用されます。
が、生成結果にEXIFが残っていたままだと、ブラウザによってそのEXIFが解釈され、再度回転される挙動があることがわかったので、生成結果からEXIFを取り除きます。