### PR TITLE
QEMUではなくGitHub Hosted Runnerのubuntu-24.04-armを使う

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        go_version: [ 1.21 ]
+        include:
+        - os: ubuntu-latest
+          platform: linux/amd64
+        - os: ubuntu-24.04-arm
+          platform: linux/arm64
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -22,6 +26,6 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ matrix.go_version }}
+        go-version-file: go.mod
     - name: Test
       run: go test -v .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,14 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+        - os: ubuntu-latest
+          platform: linux/amd64
+        - os: ubuntu-24.04-arm
+          platform: linux/arm64
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -18,9 +25,6 @@ jobs:
         with:
           images: |
             ghcr.io/pepabo/oyaki
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -37,6 +41,6 @@ jobs:
         with:
           build-args: OYAKI_VERSION=${{ steps.meta.outputs.version }}
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,10 @@ jobs:
         include:
         - os: ubuntu-latest
           platform: linux/amd64
+          suffix: ""
         - os: ubuntu-24.04-arm
           platform: linux/arm64
+          suffix: "-arm"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -43,4 +45,4 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ghcr.io/pepabo/oyaki:${{ github.ref_name }}${{ matrix.suffix }}


### PR DESCRIPTION
QEMUで不安定になっている可能性を鑑みて、GitHubが提供するubuntu-24.04-armを使ってみます。