### PR TITLE
libvipsのバージョンを上げるため、DebianベースからUbuntuベースにイメージを切り替える

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-bullseye AS build
+FROM golang:1.24-bookworm AS build
 
 ARG OYAKI_VERSION
 
@@ -8,7 +8,7 @@ COPY . /go/src/oyaki
 RUN apt update && apt install -y libvips-dev
 RUN go build -ldflags "-s -w -X main.version=${OYAKI_VERSION}" -o /go/bin/oyaki
 
-FROM debian:bookworm
+FROM ubuntu:noble
 
 RUN apt update && apt install -y libvips-dev
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/pepabo/oyaki
 
-go 1.19
+go 1.24
 
 require github.com/h2non/bimg v1.1.9


### PR DESCRIPTION
debianイメージではapt installで得られるlibvipsのバージョンが古く、DockerコンテナでEXIF stripが再現しなかった問題について、Ubuntu 24.04(noble)を使うことで解決できるのでそのようにします。

ついでにGoのバージョンも最新に上げます。