### PR TITLE
libvipsの画像読み込みをsequential accessにする

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -6,8 +6,37 @@ import (
 	"github.com/davidbyttow/govips/v2/vips"
 )
 
+// loadImage は libvips に画像を読み込む。
+// oyaki は decode→re-encode の一方向パイプラインのみで random access を必要としない。
+// EXIF orientation が 1(無回転)の画像は VIPS_ACCESS_SEQUENTIAL で読み込むことで、
+// libvips が全画素をメモリ展開せずタイル単位でストリーミング処理し、大きな画像での
+// RSS を抑えられる(OOM 対策)。
+// 一方、回転/反転を伴う orientation の画像は sequential だと AutoRotate 時に
+// "out of order read" でエラーになるため、random access にフォールバックする。
+// ヘッダ読み込みは遅延評価で画素デコードを伴わないため、フォールバック時も
+// 二重デコードは発生しない。
+func loadImage(src []byte) (*vips.ImageRef, error) {
+	params := vips.NewImportParams()
+	params.Access.Set(vips.AccessSequential)
+
+	img, err := vips.LoadImageFromBuffer(src, params)
+	if err != nil {
+		return nil, err
+	}
+
+	if img.Orientation() == 1 {
+		return img, nil
+	}
+
+	// sequential で投機的にロードした img はここで使わず捨てる。
+	// govips は GC/finalizer 経由でも解放するが、高負荷時は追いつかず OOM するため、
+	// ネイティブメモリ(VipsImage)を即時解放してから random access で読み直す。
+	img.Close()
+	return vips.NewImageFromBuffer(src)
+}
+
 func convert(src []byte, q int) (*bytes.Buffer, error) {
-	img, err := vips.NewImageFromBuffer(src)
+	img, err := loadImage(src)
 	if err != nil {
 		return nil, err
 	}

--- a/webp.go
+++ b/webp.go
@@ -42,7 +42,8 @@ func doWebp(req *http.Request) (*http.Response, error) {
 }
 
 func convWebp(src []byte, quality int) (*bytes.Buffer, error) {
-	img, err := vips.NewImageFromBuffer(src)
+	// convert() と同様、orientation に応じて sequential/random を出し分けてメモリを抑える(OOM 対策)。
+	img, err := loadImage(src)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
  ## 概要

  画像の読み込みを `VIPS_ACCESS_RANDOM`（libvips の既定）から、可能な場合に
  `VIPS_ACCESS_SEQUENTIAL` へ切り替え、大きな画像変換時のメモリ使用量（RSS）を
  抑えOOMを防ぎやすくします。

  ## 背景

  oyaki は「画像をデコードして再エンコードする」一方向のパイプラインのみで、
  画素へのランダムアクセスを必要としません。govips の `NewImageFromBuffer` は
  内部で `VIPS_ACCESS_RANDOM` を使うため、libvips が全画素をメモリ上に展開し、
  大きな画像でRSSが膨らみます。

  `VIPS_ACCESS_SEQUENTIAL` では libvips がタイル単位でストリーミング処理を行い、
  全画素を同時にメモリ展開しないため、変換時のピークメモリを削減できます。

  ## 変更点

  - `convert.go` に `loadImage()` を新設
    - orientation==1（無回転）の画像は `VIPS_ACCESS_SEQUENTIAL` で読み込む
    - 回転/反転を伴う orientation の画像は、sequential だと AutoRotate 時に
      out-of-order read でエラーになるため random access にフォールバック
    - フォールバック時は投機的に読んだ `ImageRef` を `Close()` で即時解放してから
      読み直す（GC/finalizer 任せだと高負荷時に解放が追いつかずOOMしうるため）
  - `convert()` / `convWebp()` の読み込みを `loadImage()` に統一

  ## 補足

  - ヘッダ読み込みは遅延評価で画素デコードを伴わないため、フォールバック時も
    二重デコードのオーバーヘッドは発生しません。
  - 出力（変換結果）は従来と同一です。挙動の変更はメモリ使用量の最適化のみです。
